### PR TITLE
🔧 [OOM] oom-test 자동 수정

### DIFF
--- a/values/oom-test.yaml
+++ b/values/oom-test.yaml
@@ -17,10 +17,10 @@ app:
     # 리소스 설정 (에이전트가 수정할 대상)
     resources:
       requests:
-        memory: "64Mi"
+        memory: "256Mi"
         cpu: "50m"
       limits:
-        memory: "128Mi"  # 낮게 설정하여 OOM 유발
+        memory: "512Mi"  # 프로세스 요구량(256M)을 수용할 수 있도록 메모리 제한 상향 조정
         cpu: "100m"
 
     # stress 명령어 인자


### PR DESCRIPTION
## 🔧 DR-Kube 자동 수정

### 이슈 정보
- **타입**: oom
- **리소스**: oom-test
- **네임스페이스**: default
- **심각도**: high

### 근본 원인
컨테이너에 설정된 메모리 제한(128Mi)이 실행 중인 프로세스(stress)의 메모리 요구량을 수용하지 못해 커널에 의해 강제 종료됨.

### 변경 내용
프로세스의 메모리 사용량(256M)을 충분히 수용할 수 있도록 컨테이너의 memory requests를 256Mi로, limits를 512Mi로 상향 조정하여 OOMKilled 이슈를 해결했습니다.

### 수정된 파일
- `values/oom-test.yaml`

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
