### PR TITLE
🔧 [OOM] oom-test 자동 수정

### DIFF
--- a/values/oom-test.yaml
+++ b/values/oom-test.yaml
@@ -17,11 +17,11 @@ app:
     # 리소스 설정 (에이전트가 수정할 대상)
     resources:
       requests:
-        memory: "64Mi"
-        cpu: "50m"
-      limits:
-        memory: "128Mi"  # 낮게 설정하여 OOM 유발
+        memory: "256Mi"
         cpu: "100m"
+      limits:
+        memory: "512Mi"  # stress 인자(256M)보다 높게 설정하여 OOM 방지
+        cpu: "200m"
 
     # stress 명령어
     command:


### PR DESCRIPTION
## 🔧 DR-Kube 자동 수정

### 이슈 정보
- **타입**: oom
- **리소스**: oom-test
- **네임스페이스**: default
- **심각도**: high

### 근본 원인
컨테이너 `stress-app`이 설정된 메모리 제한(Memory Limit)을 초과하여 커널 OOM 킬러에 의해 프로세스가 강제 종료되었습니다.

### 변경 내용
애플리케이션의 실제 메모리 사용량(256M)을 수용할 수 있도록 리소스 Limit을 512Mi, Request를 256Mi로 상향 조정하여 OOMKilled 이슈를 해결했습니다.

### 수정된 파일
- `values/oom-test.yaml`

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
