### PR TITLE
🔧 [CPU_THROTTLE] crash-test 자동 수정

### DIFF
--- a/values/crash-test.yaml
+++ b/values/crash-test.yaml
@@ -19,11 +19,11 @@ app:
 
     resources:
       requests:
-        memory: "32Mi"
-        cpu: "50m"
-      limits:
         memory: "64Mi"
-        cpu: "100m"
+        cpu: "200m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
 
   labels:
     scenario: crash-loop


### PR DESCRIPTION
## 🔧 DR-Kube 자동 수정

### 이슈 정보
- **타입**: cpu_throttle
- **리소스**: crash-test
- **네임스페이스**: default
- **심각도**: high

### 근본 원인
CPU Limit 설정값이 애플리케이션의 실제 연산 요구량보다 낮아 커널의 CFS 스케줄러에 의해 프로세스 실행이 강제로 제한됨.

### 변경 내용
CPU Throttling 이슈 해결을 위해 CPU Limit을 100m에서 500m로 상향 조정하고, 안정성을 위해 Request 값과 메모리 할당량도 함께 증설하였습니다.

### 수정된 파일
- `values/crash-test.yaml`

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
