### PR TITLE
🔧 [CPU_THROTTLE] oom-test 자동 수정

### DIFF
--- a/values/oom-test.yaml
+++ b/values/oom-test.yaml
@@ -17,11 +17,11 @@ app:
     # 리소스 설정 (에이전트가 수정할 대상)
     resources:
       requests:
-        memory: "64Mi"
-        cpu: "50m"
+        memory: "256Mi"
+        cpu: "200m"
       limits:
-        memory: "128Mi"  # 낮게 설정하여 OOM 유발
-        cpu: "100m"
+        memory: "512Mi"  # OOM 방지를 위해 stress 인자(256M)보다 높게 설정
+        cpu: "500m"      # CPU Throttling 방지를 위해 한도 상향 조정
 
     # stress 명령어
     command:


### PR DESCRIPTION
## 🔧 DR-Kube 자동 수정

### 이슈 정보
- **타입**: cpu_throttle
- **리소스**: oom-test
- **네임스페이스**: default
- **심각도**: high

### 근본 원인
컨테이너의 CPU 사용량이 설정된 `limits`를 초과하여 커널(CFS)에 의해 프로세스 실행 시간이 강제로 제한되고 있습니다.

### 변경 내용
CPU Throttling 및 OOM 문제를 해결하기 위해 CPU limits를 500m로, Memory limits를 512Mi로 상향 조정하고 그에 맞춰 requests 값도 최적화하였습니다.

### 수정된 파일
- `values/oom-test.yaml`

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
