### PR TITLE
🔧 [CPU_THROTTLE] crash-test 자동 수정

### DIFF
--- a/values/crash-test.yaml
+++ b/values/crash-test.yaml
@@ -19,11 +19,11 @@ app:
 
     resources:
       requests:
-        memory: "32Mi"
-        cpu: "50m"
-      limits:
         memory: "64Mi"
-        cpu: "100m"
+        cpu: "200m"
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
 
   labels:
     scenario: crash-loop


### PR DESCRIPTION
## 🔧 DR-Kube 자동 수정

### 이슈 정보
- **타입**: cpu_throttle
- **리소스**: crash-test
- **네임스페이스**: default
- **심각도**: high

### 근본 원인
설정된 CPU Limit이 애플리케이션의 실제 연산 요구량보다 낮아 CFS(Completely Fair Scheduler)에 의해 CPU 할당 시간이 강제로 제한됨.

### 변경 내용
CPU Throttling 해결을 위해 CPU Limit을 100m에서 500m로 상향 조정하고, 안정적인 자원 확보를 위해 Memory 및 CPU Request 값도 함께 증설하였습니다.

### 수정된 파일
- `values/crash-test.yaml`

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
