### PR TITLE
🔧 [CPU_THROTTLE] cpu-test 자동 수정

### DIFF
--- a/values/cpu-test.yaml
+++ b/values/cpu-test.yaml
@@ -1,5 +1,5 @@
 # DR-Kube CPU Throttle 테스트용 애플리케이션
-# CPU limit을 낮게 설정하여 throttling 유발
+# CPU limit을 워크로드에 맞게 상향 조정하여 throttling 해결
 
 app:
   name: cpu-test
@@ -18,14 +18,14 @@ app:
     resources:
       requests:
         memory: "64Mi"
-        cpu: "50m"
+        cpu: "2000m"
       limits:
         memory: "256Mi"
-        cpu: "100m"  # 낮게 설정하여 CPU throttling 유발
+        cpu: "2000m"  # stress 워커 수(2개)에 맞춰 CPU 제한을 2000m(2 Core)로 상향
 
     args:
       - "--cpu"
-      - "2"         # CPU 워커 2개 (100m limit 초과)
+      - "2"         # CPU 워커 2개 (2000m 사용량에 대응)
       - "--timeout"
       - "3600"      # 1시간 실행
 


### PR DESCRIPTION
## 🔧 DR-Kube 자동 수정

### 이슈 정보
- **타입**: cpu_throttle
- **리소스**: cpu-test
- **네임스페이스**: default
- **심각도**: high

### 근본 원인
컨테이너의 CPU 사용량이 설정된 `limits`를 초과하여 커널(CFS)에 의해 프로세스 실행 시간이 강제로 제한되고 있습니다.

### 변경 내용
`stress` 워커 수(2개)에 의한 CPU 사용량에 맞춰 `resources.limits.cpu`와 `requests.cpu`를 `2000m`(2 Core)으로 상향 조정하여 Throttling을 해결했습니다.

### 수정된 파일
- `values/cpu-test.yaml`

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
