### PR TITLE
🔧 [OOM] oom-test 자동 수정

### DIFF
--- a/values/oom-test.yaml
+++ b/values/oom-test.yaml
@@ -17,10 +17,10 @@ app:
     # 리소스 설정 (에이전트가 수정할 대상)
     resources:
       requests:
-        memory: "256Mi"
+        memory: "512Mi"
         cpu: "200m"
       limits:
-        memory: "512Mi"  # OOM 방지를 위해 실제 사용량(256M)보다 높게 설정
+        memory: "1Gi"    # OOM 방지를 위해 메모리 한계치를 1Gi로 상향 조정
         cpu: "500m"      # CPU Throttling 방지를 위해 Limit 상향 조정
 
     # stress 명령어


### PR DESCRIPTION
## 🔧 DR-Kube 자동 수정

### 이슈 정보
- **타입**: oom
- **리소스**: oom-test
- **네임스페이스**: default
- **심각도**: high

### 근본 원인
컨테이너가 설정된 메모리 제한(Limit)을 초과하여 사용함에 따라 커널 OOM Killer에 의해 프로세스가 강제 종료되었습니다.

### 변경 내용
컨테이너의 메모리 사용량(256M)에 비해 부족했던 리소스 제한을 `requests: 512Mi`, `limits: 1Gi`로 상향 조정하여 OOMKilled 이슈를 해결했습니다.

### 수정된 파일
- `values/oom-test.yaml`

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
