### PR TITLE
🔧 [OOM] oom-test 자동 수정

### DIFF
--- a/values/oom-test.yaml
+++ b/values/oom-test.yaml
@@ -17,10 +17,10 @@ app:
     # 리소스 설정 (에이전트가 수정할 대상)
     resources:
       requests:
-        memory: "256Mi"
+        memory: "512Mi"
         cpu: "500m"
       limits:
-        memory: "512Mi"  # OOM 방지를 위해 실제 사용량(256M)보다 높게 설정
+        memory: "1Gi"  # OOM 방지를 위해 실제 사용량 및 피크치를 고려하여 1Gi로 상향 조정
         cpu: "1000m"     # CPU Throttling 방지를 위해 Limit 상향 조정
 
     # stress 명령어
@@ -32,7 +32,7 @@ app:
       - "--vm"
       - "1"
       - "--vm-bytes"
-      - "256M"  # 128Mi limit보다 큰 값으로 OOM 유발
+      - "256M"  # 실제 사용량에 맞춰 리소스 Limit을 상향 조정하여 OOM 해결
       - "--vm-hang"
       - "1"
 


### PR DESCRIPTION
## 🔧 DR-Kube 자동 수정

### 이슈 정보
- **타입**: oom
- **리소스**: oom-test
- **네임스페이스**: default
- **심각도**: high

### 근본 원인
컨테이너의 실제 메모리 사용량이 설정된 Memory Limit을 초과하여 커널 OOM 킬러에 의해 프로세스가 강제 종료됨.

### 변경 내용
컨테이너의 실제 메모리 사용량(256M)과 오버헤드를 고려하여 Memory Limit을 512Mi에서 1Gi로, Requests를 256Mi에서 512Mi로 상향 조정하여 OOMKilled 이슈를 해결했습니다.

### 수정된 파일
- `values/oom-test.yaml`

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
