### PR TITLE
🔧 [CPU_THROTTLE] oom-test 자동 수정

### DIFF
--- a/values/oom-test.yaml
+++ b/values/oom-test.yaml
@@ -17,11 +17,11 @@ app:
     # 리소스 설정 (에이전트가 수정할 대상)
     resources:
       requests:
-        memory: "256Mi"
-        cpu: "500m"
+        memory: "512Mi"
+        cpu: "1000m"
       limits:
-        memory: "512Mi"  # OOM 방지를 위해 실제 사용량(256M)보다 높게 설정
-        cpu: "1000m"     # CPU Throttling 방지를 위해 Limit 상향 조정
+        memory: "1024Mi"  # OOM 방지를 위해 실제 사용량보다 충분히 높게 설정
+        cpu: "2000m"     # CPU Throttling 방지를 위해 Limit을 기존 대비 2배 상향 조정
 
     # stress 명령어
     command:


### PR DESCRIPTION
## 🔧 DR-Kube 자동 수정

### 이슈 정보
- **타입**: cpu_throttle
- **리소스**: oom-test
- **네임스페이스**: default
- **심각도**: high

### 근본 원인
애플리케이션의 CPU 사용량이 설정된 `limits.cpu`를 초과하여 커널 CFS 스케줄러에 의해 프로세스 점유 시간이 강제로 제한됨.

### 변경 내용
CPU Throttling 해결을 위해 `limits.cpu`를 2000m로 상향 조정하고, 안정적인 리소스 확보를 위해 `requests` 및 `memory` 설정을 최적화하였습니다.

### 수정된 파일
- `values/oom-test.yaml`

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
