### PR TITLE
🔧 [CPU_THROTTLE] oom-test 자동 수정

### DIFF
--- a/values/oom-test.yaml
+++ b/values/oom-test.yaml
@@ -17,11 +17,11 @@ app:
     # 리소스 설정 (에이전트가 수정할 대상)
     resources:
       requests:
-        memory: "256Mi"
-        cpu: "500m"
+        memory: "512Mi"
+        cpu: "1000m"
       limits:
-        memory: "512Mi"  # OOM 방지를 위해 실제 사용량(256M)보다 높게 설정
-        cpu: "1000m"     # CPU Throttling 방지를 위해 Limit 상향 조정
+        memory: "1Gi"  # OOM 방지를 위해 실제 사용량(256M)보다 충분히 높게 설정
+        cpu: "2000m"     # CPU Throttling 방지를 위해 Limit을 기존 대비 2배 상향 조정
 
     # stress 명령어
     command:


### PR DESCRIPTION
## 🔧 DR-Kube 자동 수정

### 이슈 정보
- **타입**: cpu_throttle
- **리소스**: oom-test
- **네임스페이스**: default
- **심각도**: high

### 근본 원인
컨테이너의 CPU 사용량이 설정된 `limits.cpu`에 도달하여 커널의 CFS Quota에 의해 프로세스 실행 시간이 강제로 제한됨.

### 변경 내용
CPU Throttling 해결을 위해 `limits.cpu`를 1000m에서 2000m로 상향하고, 안정적인 자원 확보를 위해 `requests` 및 `memory limits`를 함께 조정했습니다.

### 수정된 파일
- `values/oom-test.yaml`

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
