### PR TITLE
🔧 [CPU_THROTTLE] oom-test 자동 수정

### DIFF
--- a/values/oom-test.yaml
+++ b/values/oom-test.yaml
@@ -18,10 +18,10 @@ app:
     resources:
       requests:
         memory: "256Mi"
-        cpu: "500m"
+        cpu: "1000m"
       limits:
         memory: "512Mi"  # OOM 방지를 위해 실제 사용량(256M)보다 높게 설정
-        cpu: "1000m"     # CPU Throttling 방지를 위해 Limit 상향 조정
+        cpu: "2000m"     # CPU Throttling 방지를 위해 Limit 및 Request 상향 조정
 
     # stress 명령어
     command:


### PR DESCRIPTION
## 🔧 DR-Kube 자동 수정

### 이슈 정보
- **타입**: cpu_throttle
- **리소스**: oom-test
- **네임스페이스**: default
- **심각도**: high

### 근본 원인
컨테이너에 설정된 CPU Limit이 실제 워크로드의 요구량보다 낮아 CFS(Completely Fair Scheduler)에 의해 프로세스 실행 시간이 강제로 제한됨.

### 변경 내용
CPU Throttling 이슈 해결을 위해 CPU Limit을 1000m에서 2000m로, Request를 500m에서 1000m로 상향 조정하였습니다.

### 수정된 파일
- `values/oom-test.yaml`

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
