### PR TITLE
🔧 [OOM] oom-test 자동 수정

### DIFF
--- a/values/oom-test.yaml
+++ b/values/oom-test.yaml
@@ -17,10 +17,10 @@ app:
     # 리소스 설정 (에이전트가 수정할 대상)
     resources:
       requests:
-        memory: "64Mi"
+        memory: "256Mi" # OOMKilled 방지를 위해 요청 메모리 증가
         cpu: "50m"
       limits:
-        memory: "128Mi"  # 낮게 설정하여 OOM 유발
+        memory: "256Mi" # 컨테이너가 요청하는 256M에 맞춰 메모리 제한 증가
         cpu: "100m"
 
     # stress 명령어


### PR DESCRIPTION
## 🔧 DR-Kube 자동 수정

### 이슈 정보
- **타입**: oom
- **리소스**: oom-test
- **네임스페이스**: default
- **심각도**: critical

### 근본 원인
`oom-test` 컨테이너가 할당된 메모리 제한(128Mi)을 초과하여 OOMKilled로 종료되었습니다.

### 변경 내용
`app.container.resources.limits.memory`를 컨테이너가 `--vm-bytes`로 요청하는 256M에 맞춰 "256Mi"로 상향 조정하고, `app.container.resources.requests.memory`도 "256Mi"로 상향 조정하여 OOMKilled 이슈를 해결했습니다.

### 수정된 파일
- `values/oom-test.yaml`

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
