### PR TITLE
MON-1: Improve Alloy->Loki pipeline

### DIFF
--- a/values/alloy.yaml
+++ b/values/alloy.yaml
@@ -64,10 +64,10 @@ alloy:
         }
         // version/env 라벨은 제외 (요청사항)
 
-        // 시스템 namespace 제외
+        // 시스템 namespace 제외 (kube-system, kube-public, kube-node-lease만)
         rule {
           source_labels = ["__meta_kubernetes_namespace"]
-          regex         = "kube-system|kube-public|kube-node-lease|argocd|monitoring|external-secrets"
+          regex         = "kube-system|kube-public|kube-node-lease"
           action        = "drop"
         }
       }


### PR DESCRIPTION
## 요약
- Alloy 로그 파이프라인 개선: relabel, 구조화/비구조화 파싱, 레벨 정규화, 노이즈 필터링, 레이트 리밋 추가
- Loki 전송 엔드포인트 수정
- `version`, `env` 라벨 매핑 제거

## 상세 변경 (Alloy 파이프라인)
### Discovery/Relabel
- `discovery.kubernetes`: DaemonSet 기준으로 현재 노드 파드만 수집
- `discovery.relabel`: 라벨 추가 `namespace`, `pod`, `container`, `node`, `app`
- 제외 네임스페이스: `kube-system|kube-public|kube-node-lease`

### 파싱
- `stage.docker`: Docker JSON 로그 포맷 파싱
- `stage.json`: 필드 추출 `level`, `msg`, `message`, `timestamp`, `time`, `caller`, `error`, `err`, `trace_id`, `span_id`, `request_id`, `user_id`, `method`, `path`, `status`, `duration`, `latency`
- `stage.regex`: 비구조화 로그 파싱 (Python/Celery + Django 패턴)

### 레벨 정규화
- JSON/regex/fallback에서 `level` 추출
- `warn` → `warning`, `err` → `error`로 정규화

### 노이즈 필터링
- 시스템 컨테이너 제외: `loki|alloy|kube-proxy|aws-node|coredns`
- 헬스체크/프로브/`/metrics` 요청 제외
- ELB 헬스체크, Celery beat 반복 로그, DB pool/heartbeat, static 파일 요청, Kafka 내부 로그 제외

### 레이트 리밋
- `stage.limit`: `rate=1000`, `burst=2000`

## 파일 변경
- `values/alloy.yaml`:
  - Loki 엔드포인트: `http://loki:3100/loki/api/v1/push`
  - `version`, `env` 라벨 매핑 제거
  - 드롭 네임스페이스를 시스템 3종으로 제한

## 검증 방법 (Issue 기준)

kubectl logs -l app=alloy -n monitoring 에서 Loki 전송 에러 없음 확인


Grafana Explore에서 {namespace="online-boutique"} 쿼리로 로그 확인
<img width="1502" height="775" alt="image" src="https://github.com/user-attachments/assets/69b14ed0-7992-4c5e-b022-27c2d9ee9f9d" />


{app="frontend"}, {app="cartservice"} 등 라벨 기반 필터링 동작 확인
[app=frontend]
<img width="528" height="447" alt="image" src="https://github.com/user-attachments/assets/f23585f8-d8bb-4eab-918c-1c7771340202" />

<img width="1482" height="755" alt="image" src="https://github.com/user-attachments/assets/2a645625-e372-45f6-b92c-616aca1a32ee" />

## 이슈
- Closes #1169
