### PR TITLE
MON-2: Grafana DR-Kube Overview 대시보드

### DIFF
--- a/values/grafana.yaml
+++ b/values/grafana.yaml
@@ -21,7 +21,7 @@ datasources:
       # Prometheus 설정
       - name: Prometheus
         type: prometheus
-        url: http://prometheus-server
+        url: http://prom-prometheus-server
         access: proxy
 
 initChownData:
@@ -199,7 +199,7 @@ dashboards:
                 "overrides": []
               },
               "gridPos": {
-                "h": 8,
+                "h": 10,
                 "w": 12,
                 "x": 6,
                 "y": 0
@@ -273,7 +273,7 @@ dashboards:
               },
               "targets": [
                 {
-                  "expr": "sum(increase(kube_pod_container_status_restarts_total{reason=\"OOMKilled\"}[24h]))",
+                  "expr": "sum(kube_pod_container_status_last_terminated_reason{reason=\"OOMKilled\"})",
                   "refId": "A"
                 }
               ],
@@ -418,7 +418,7 @@ dashboards:
               },
               "targets": [
                 {
-                  "expr": "kube_deployment_status_available_replicas / kube_deployment_spec_replicas",
+                  "expr": "kube_deployment_status_replicas_available / kube_deployment_spec_replicas",
                   "format": "table",
                   "instant": true,
                   "refId": "A"


### PR DESCRIPTION
## 요약
- DR-Kube Overview 대시보드 및 provider 구성 추가
- Prometheus datasource URL을 observability 기준으로 수정
- 패널 쿼리/레이아웃 보정

## 변경 사항
- `values/grafana.yaml`
  - `dashboardProviders`에 DR-Kube 폴더 추가
  - `dashboards.dr-kube.dr-kube-overview` 인라인 JSON 추가 (요약 패널 6개)
  - Prometheus datasource URL을 `http://prom-prometheus-server`로 수정
  - Deployment Replicas 쿼리 수정
    - `kube_deployment_status_replicas_available / kube_deployment_spec_replicas`
  - OOM 패널 쿼리 수정
    - `sum(kube_pod_container_status_last_terminated_reason{reason="OOMKilled"})`
  - Pod Restart(1h) 패널 높이 조정
<img width="1621" height="833" alt="image" src="https://github.com/user-attachments/assets/bcce6b71-c60b-40d1-8c97-62d785075b2a" />



## 검증
- observability 네임스페이스 Helm 업그레이드 적용
- Grafana 파드 정상 기동 및 대시보드 표시 확인

Closes #1170