### PR TITLE
MON-3: Prometheus 알림 규칙 확장

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ env/
 *~
 .DS_Store
 
+# local secrets
+_secrets/
+
 # Jupyter Notebook
 .ipynb_checkpoints
 

--- a/values/prometheus.yaml
+++ b/values/prometheus.yaml
@@ -60,16 +60,19 @@ alertmanager:
     global:
       resolve_timeout: 5m
     route:
-      receiver: "dr-kube-webhook"
+      receiver: "slack-notifications"
       group_by: ["alertname", "namespace", "pod"]
       group_wait: 10s
       group_interval: 30s
       repeat_interval: 1h
     receivers:
-      - name: "dr-kube-webhook"
-        webhook_configs:
-          - url: "http://host.docker.internal:8080/webhook/alertmanager"
-            send_resolved: false
+      - name: slack-notifications
+        slack_configs:
+          - api_url: "<SLACK_WEBHOOK_URL>"   # 별도 파일에서 관리
+            channel: "#alert"
+            send_resolved: true
+            title: "{{ .CommonAnnotations.summary }}"
+            text: "{{ .CommonAnnotations.description }}"
 
 # ============================================
 # Node Exporter (DaemonSet)


### PR DESCRIPTION
## 요약
- Prometheus 알림 규칙을 3개 → 8개로 확장
- 모든 신규 알림에 한글 summary/description 추가

## 변경 사항
- `values/prometheus.yaml`
  - HighMemoryUsage
  - PodNotReady
  - ContainerWaiting
  - DeploymentReplicasMismatch
  - NodeHighCPU

## 알림 상세
- HighMemoryUsage: 메모리 사용률 85% 초과 (2m)
- PodNotReady: Ready 조건 false 지속 (5m)
- ContainerWaiting: ContainerCreating 이외 waiting 감지 (5m)
- DeploymentReplicasMismatch: spec vs available 불일치 (5m)
- NodeHighCPU: 노드 CPU 80% 초과 (5m)
<img width="1888" height="826" alt="image" src="https://github.com/user-attachments/assets/de5bb608-e2e9-4157-9345-6ad159c16f99" />
<img width="1887" height="267" alt="image" src="https://github.com/user-attachments/assets/39a61164-41b7-4b86-9b09-bbe77c2a0baf" />

<img width="976" height="577" alt="image" src="https://github.com/user-attachments/assets/c1501673-f168-4dfb-b0c0-2278bedd82bf" />

Closes #1171
