### PR TITLE
fix(unknown): scale replicas and memory

### DIFF
--- a/values/online-boutique.yaml
+++ b/values/online-boutique.yaml
@@ -22,14 +22,14 @@ googleCloudOperations:
 # ============================================
 frontend:
   enabled: true
-  replicas: 1
+  replicas: 3
   resources:
     requests:
       cpu: 50m
-      memory: 64Mi
+      memory: 128Mi
     limits:
       cpu: 100m
-      memory: 128Mi # ← 에이전트가 수정할 대상 (OOMKilled 유발)
+      memory: 256Mi # ← 에이전트가 수정할 대상 (OOMKilled 유발)
   externalService: false
   service:
     type: ClusterIP


### PR DESCRIPTION
## DR-Kube 자동 수정

### 이슈 정보
| 항목 | 값 |
|------|-----|
| 타입 | `composite_incident` |
| 리소스 | `unknown` |
| 네임스페이스 | `online-boutique` |
| 심각도 | **critical** |

### 근본 원인
프론트엔드 서비스의 메모리 부족(OOMKilled)으로 인한 잦은 재시작과 단일 레플리카 구성으로 인한 가용성 저하가 복합적으로 발생함.

### 변경 내용
`values/online-boutique.yaml`

```diff
@@ -22,14 +22,14 @@
-  replicas: 1
-  resources:
-    requests:
-      cpu: 50m
-      memory: 64Mi
-    limits:
-      cpu: 100m
-      memory: 128Mi # ← 에이전트가 수정할 대상 (OOMKilled 유발)
+  replicas: 3
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi # ← 에이전트가 수정할 대상 (OOMKilled 유발)
@@ -209,4 +209,4 @@
-  enabled: false # ← 수동 테스트를 위해 비활성화
+  enabled: false # ← 수동 테스트를 위해 비활성화
```

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
