### PR TITLE
fix(paymentservice): scale up and increase memory

### DIFF
--- a/values/online-boutique.yaml
+++ b/values/online-boutique.yaml
@@ -91,14 +91,14 @@ currencyservice:
 # ============================================
 paymentservice:
   enabled: true
-  replicas: 1
+  replicas: 2
   resources:
     requests:
       cpu: 50m
-      memory: 64Mi
+      memory: 128Mi
     limits:
       cpu: 100m
-      memory: 128Mi
+      memory: 256Mi
   service:
     type: ClusterIP
     port: 8081


### PR DESCRIPTION
## DR-Kube 자동 수정

### 이슈 정보
| 항목 | 값 |
|------|-----|
| 타입 | `composite_incident` |
| 리소스 | `paymentservice` |
| 네임스페이스 | `online-boutique` |
| 심각도 | **critical** |

### 근본 원인
`paymentservice`의 메모리 부족(OOMKilled)으로 인한 서비스 중단이 `frontend` 등 상위 서비스의 연쇄 장애를 유발함.

### 변경 내용
`values/online-boutique.yaml`

```diff
@@ -91,14 +91,14 @@
-  replicas: 1
-  resources:
-    requests:
-      cpu: 50m
-      memory: 64Mi
-    limits:
-      cpu: 100m
-      memory: 128Mi
+  replicas: 2
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 256Mi
@@ -209,4 +209,4 @@
-  enabled: false # ← 수동 테스트를 위해 비활성화
+  enabled: false # ← 수동 테스트를 위해 비활성화
```

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
