### PR TITLE
fix(unknown): "increase frontend replicas to 2, add timeout"

### DIFF
--- a/values/online-boutique.yaml
+++ b/values/online-boutique.yaml
@@ -22,7 +22,7 @@ googleCloudOperations:
 # ============================================
 frontend:
   enabled: true
-  replicas: 1
+  replicas: 2 # Increased replicas for higher availability
   resources:
     requests:
       cpu: 50m
@@ -34,6 +34,7 @@ frontend:
   service:
     type: ClusterIP
     port: 80
+  timeout: 5s # Added timeout to improve network stability
 
 # ============================================
 # Cart Service (Redis 기반인거 같음)


### PR DESCRIPTION
## DR-Kube 자동 수정

### 이슈 정보
| 항목 | 값 |
|------|-----|
| 타입 | `LogErrorDetected` |
| 리소스 | `unknown` |
| 네임스페이스 | `online-boutique` |
| 심각도 | **medium** |

### 근본 원인
`frontend` 서비스에서 에러 레벨 로그가 감지되었으며, 이는 트래픽 처리 중 오류가 발생했음을 나타냅니다. 현재 설정에서 `frontend` 서비스의 리소스 제한이 낮거나, 트래픽 처리 안정성을 위한 설정이 부족할 가능성이 있습니다.

### 변경 내용
`values/online-boutique.yaml`

```diff
@@ -22,7 +22,7 @@
-  replicas: 1
+  replicas: 2 # Increased replicas for higher availability
@@ -34,6 +34,7 @@
+  timeout: 5s # Added timeout to improve network stability
```

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
