### PR TITLE
fix(frontend): enforce frontend min availability

### DIFF
--- a/values/online-boutique.yaml
+++ b/values/online-boutique.yaml
@@ -23,6 +23,9 @@ googleCloudOperations:
 frontend:
   enabled: true
   replicas: 1
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
## DR-Kube 자동 수정

### 이슈 정보
| 항목 | 값 |
|------|-----|
| 타입 | `replicas_mismatch` |
| 리소스 | `frontend` |
| 네임스페이스 | `online-boutique` |
| 심각도 | **high** |

### 근본 원인
frontend Deployment의 desired replicas 값이 0으로 반영되어 서비스 Pod가 강제로 모두 내려갔습니다.

### 변경 내용
`values/online-boutique.yaml`

```diff
@@ -23,6 +23,9 @@
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
```

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
