### PR TITLE
fix(cartservice): "scale cartservice + add timeout"

### DIFF
--- a/values/online-boutique.yaml
+++ b/values/online-boutique.yaml
@@ -43,7 +43,10 @@ frontend:
 # ============================================
 cartservice:
   enabled: true
-  replicas: 1
+  replicas: 2
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
   resources:
     requests:
       cpu: 50m
@@ -54,6 +57,7 @@ cartservice:
   service:
     type: ClusterIP
     port: 7070
+  timeout: 5s
 
 # ============================================
 # Product Catalog Service


### PR DESCRIPTION
## DR-Kube 자동 수정

### 이슈 정보
| 항목 | 값 |
|------|-----|
| 타입 | `KubePodCrashLooping` |
| 리소스 | `cartservice` |
| 네임스페이스 | `online-boutique` |
| 심각도 | **high** |

### 근본 원인
cartservice 파드가 메모리 제한(128Mi) 대비 실제 사용량이 높아 OOMKilled로 반복 재시작되고 있습니다.

### 변경 내용
`values/online-boutique.yaml`

```diff
@@ -43,7 +43,10 @@
-  replicas: 1
+  replicas: 2
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
@@ -54,6 +57,7 @@
+  timeout: 5s
```

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
