### PR TITLE
fix(cartservice): raise cartservice memory limits

### DIFF
--- a/values/online-boutique.yaml
+++ b/values/online-boutique.yaml
@@ -47,10 +47,10 @@ cartservice:
   resources:
     requests:
       cpu: 50m
-      memory: 256Mi
+      memory: 384Mi
     limits:
       cpu: 100m
-      memory: 512Mi
+      memory: 768Mi
   service:
     type: ClusterIP
     port: 7070


### PR DESCRIPTION
## DR-Kube 자동 수정

### 이슈 정보
| 항목 | 값 |
|------|-----|
| 타입 | `oom` |
| 리소스 | `cartservice` |
| 네임스페이스 | `online-boutique` |
| 심각도 | **high** |

### 근본 원인
cartservice 컨테이너의 메모리 제한값이 실제 사용량보다 낮게 설정되어 OOMKilled가 발생했습니다.

### 변경 내용
`values/online-boutique.yaml`

```diff
@@ -47,10 +47,10 @@
-      memory: 256Mi
-    limits:
-      cpu: 100m
-      memory: 512Mi
+      memory: 384Mi
+    limits:
+      cpu: 100m
+      memory: 768Mi
```

---
> 이 PR은 DR-Kube 에이전트에 의해 자동 생성되었습니다.
